### PR TITLE
pages-deploy.yml変更。jekyllのオプションの順番を修正

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -46,7 +46,7 @@ jobs:
           bundler-cache: true
 
       - name: Build site
-        run: bundle exec jekyll b -b --trace "${{ steps.pages.outputs.base_path }}/"
+        run: bundle exec jekyll b --trace -b "${{ steps.pages.outputs.base_path }}/"
         env:
           JEKYLL_ENV: "production"
 


### PR DESCRIPTION
-b(--base-url)は引数をとっており、このままだと`--base-url='--trace'`の意味になってしまうのを修正